### PR TITLE
fix: use VITE_API_BASE_URL env var for production API + add vercel.js…

### DIFF
--- a/react-frontend/src/services/api.js
+++ b/react-frontend/src/services/api.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:10000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL 
+  ? `${import.meta.env.VITE_API_BASE_URL}/api`
+  : 'http://localhost:5000/api';
 
 const api = axios.create({
   baseURL: API_BASE_URL,

--- a/react-frontend/vercel.json
+++ b/react-frontend/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
…on for SPA routing

- api.js was hardcoded to localhost:10000 causing all API calls to fail on Vercel
- Now reads VITE_API_BASE_URL env variable with localhost:5000 fallback for dev
- Added vercel.json to rewrite all routes to index.html (fixes direct URL navigation)